### PR TITLE
support web DIDs

### DIFF
--- a/src/app/actions.tsx
+++ b/src/app/actions.tsx
@@ -17,10 +17,10 @@ export async function resolveHandle(_: string | undefined, formData: FormData) {
   }
 
   if (handle.startsWith("did:")) {
-    if (handle.startsWith("did:plc:")) {
+    if (handle.startsWith("did:plc:") || handle.startsWith("did:web:")) {
       redirect(`/did/${handle}`);
     } else {
-      return "Non-PLC DIDs are not supported by this tool.";
+      return "Only PLC & web DIDs are currently supported by this tool.";
     }
   } else {
     if (handle.startsWith("@")) handle = handle.slice(1);
@@ -31,10 +31,10 @@ export async function resolveHandle(_: string | undefined, formData: FormData) {
     });
 
     if (res.success) {
-      if (res.data.did.startsWith("did:plc:")) {
+      if (res.data.did.startsWith("did:plc:") || res.data.did.startsWith("did:web:")) {
         redirect(`/did/${res.data.did}`);
       } else {
-        return "Non-PLC DIDs are not supported by this tool.";
+        return "Only PLC & web DIDs are currently supported by this tool.";
       }
     } else {
       return "Handle not found. Are you sure it's correct?";


### PR DESCRIPTION
This PR implements did:web support by adding a few more checks. It adds checks for DIDs starting with "did:web:". Then, instead of pulling from the PLC directory, it pulls from `https://$didDomain/.well-known/did.json`. Instead of linking to the PLC registry on the result page, we link to the `did.json` directly. Audit history isn't available, so we leave a placeholder stating that the account creation date is unknown. 